### PR TITLE
Active run error handling

### DIFF
--- a/R/globals.R
+++ b/R/globals.R
@@ -33,7 +33,7 @@ exists_active_run <- function() {
       get_active_run_id()
       return(TRUE)
     },
-    error = function(e) {return(FALSE)}
+    error = function(e) return(FALSE)
   )
 }
 

--- a/R/globals.R
+++ b/R/globals.R
@@ -21,10 +21,20 @@ pop_active_run_id <- function() {
 #' @export
 get_active_run_id <- function() {
   if (length(.globals$active_run_stack) == 0) {
-    NULL
+    abort("No active run. Hint: Maybe either supply a `run_id` or start a run with `start_run`?")
   } else {
     .globals$active_run_stack[length(.globals$active_run_stack)]
   }
+}
+
+exists_active_run <- function() {
+  tryCatch(
+    {
+      get_active_run_id()
+      return(TRUE)
+    },
+    error = function(e) {return(FALSE)}
+  )
 }
 
 #' Set an experiment to `active`

--- a/R/runs.R
+++ b/R/runs.R
@@ -127,7 +127,7 @@ delete_run <- function(run_id = get_active_run_id(), client = mlflow_client()) {
   assert_string(run_id)
   assert_mlflow_client(client)
 
-  if (identical(run_id, get_active_run_id())) {
+  if (exists_active_run() && identical(run_id, get_active_run_id())) {
     abort("Cannot delete an active run.")
   }
 
@@ -798,6 +798,7 @@ get_run_context.default <- function(client, experiment_id, ...) {
   tags[[MLFLOW_TAGS$MLFLOW_SOURCE_NAME]] <- get_source_name()
   tags[[MLFLOW_TAGS$MLFLOW_SOURCE_VERSION]] <- get_source_version()
   tags[[MLFLOW_TAGS$MLFLOW_SOURCE_TYPE]] <- MLFLOW_SOURCE_TYPE$LOCAL
+
   if (exists_active_run()) {
     # create a tag containing the parent run ID so that MLflow UI can display
     # nested runs properly
@@ -838,7 +839,7 @@ end_run <- function(status = c("FINISHED", "FAILED", "KILLED"), end_time = curre
     end_time = end_time
   )
 
-  if (identical(run_id, get_active_run_id())) pop_active_run_id()
+  if (exists_active_run() && identical(run_id, get_active_run_id())) pop_active_run_id()
 
   run
 }

--- a/R/runs.R
+++ b/R/runs.R
@@ -754,13 +754,11 @@ start_run <- function(run_id = Sys.getenv("MLFLOW_RUN_ID"), experiment_id = get_
   assert_string(experiment_id)
   assert_mlflow_client(client)
 
-  active_run_id <- get_active_run_id()
-
-  if (!is.null(active_run_id) && !nested) {
+  if (exists_active_run() && !nested) {
     abort(
       paste(
         "Run with id",
-        active_run_id,
+        get_active_run_id(),
         "is already active. To start a nested run, Call `start_run()` with `nested = TRUE`."
       )
     )
@@ -800,11 +798,10 @@ get_run_context.default <- function(client, experiment_id, ...) {
   tags[[MLFLOW_TAGS$MLFLOW_SOURCE_NAME]] <- get_source_name()
   tags[[MLFLOW_TAGS$MLFLOW_SOURCE_VERSION]] <- get_source_version()
   tags[[MLFLOW_TAGS$MLFLOW_SOURCE_TYPE]] <- MLFLOW_SOURCE_TYPE$LOCAL
-  parent_run_id <- get_active_run_id()
-  if (!is.null(parent_run_id)) {
+  if (exists_active_run()) {
     # create a tag containing the parent run ID so that MLflow UI can display
     # nested runs properly
-    tags[[MLFLOW_TAGS$MLFLOW_PARENT_run_id]] <- parent_run_id
+    tags[[MLFLOW_TAGS$MLFLOW_PARENT_run_id]] <- get_active_run_id()
   }
   list(
     client = client,

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,7 +27,11 @@ get_source_version <- function() {
 }
 
 get_active_run_id_or_start_run <- function() {
-  get_active_run_id() %||% mlflow_id(start_run())
+  if (exists_active_run()) {
+    get_active_run_id()
+  } else {
+    mlflow_id(start_run())
+  }
 }
 
 
@@ -70,7 +74,7 @@ infer_experiment_id <- function() {
 #' @export
 with.mlflow_run <- function(data, expr, ...) {
   run_id <- mlflow_id(data)
-  if (!identical(run_id, get_active_run_id())) {
+  if (exists_active_run() && !identical(run_id, get_active_run_id())) {
     abort("`with()` should only be used with `start_run()`.")
   }
 


### PR DESCRIPTION
@tonyelhabr I _think_ this should fix a bunch of the weird 500s you'd get when (e.g.) trying to call `log_params()` without an active run. Instead of `get_active_run_id()` returning `NULL` and then the API call bombing as a result, `get_active_run_id()` will just throw an error instead with a helpful hint. Here's a `prex`:

``` r
log_params("foo")
#> Error: No active run. Hint: Maybe either supply a `run_id` or start a run with `start_run`?

with.mlflow_run(
    start_run(experiment_id = "783"), {
        log_params("foo")
    }
)

log_params("foo")
#> Error: No active run. Hint: Maybe either supply a `run_id` or start a run with `start_run`?
```