### PR TITLE
Version `0.5.1`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: lightMLFlow
 Title: A lightweight R wrapper for the MLFlow REST API
-Version: 0.5.0
+Version: 0.5.1
 Authors@R: 
     person(given = "Matt",
            family = "Kaye",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# lightMLFlow 0.5.1
+
+* Fixes a bug that would leave a GH token in plain text in the run
+
 # lightMLFlow 0.5.0
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/project.R
+++ b/R/project.R
@@ -10,7 +10,7 @@
 #' @param run_id An MLFlow run ID. Auto-generated if missing
 #' @param client An MLFlow client. Auto-generated if missing
 #' @param git_repo_url A URL for the Git repo where the code is being run from
-#' This is expected to be of the form `https://<<GITHUB_TOKEN>>@github.com/<<org>>/<<repo>>`
+#' This is expected to be of the form `https://github.com/<<org>>/<<repo>>`
 #' @param git_repo_subdir The subdirectory in the repo where your code lives
 #' @param source_git_commit A git commit hash to tag a run with. Defaults to \code{git2r::revparse_single(".", revision = "HEAD")$sha}
 #' @param source_git_branch The git branch the code is running on. Defaults to \code{system("git rev-parse --abbrev-ref HEAD", intern = TRUE)} (i.e. the current branch)
@@ -23,18 +23,22 @@ set_git_tracking_tags <- function(
   run_id = get_active_run_id(),
   client = mlflow_client(),
   git_repo_url = Sys.getenv("GIT_REPO_URL"),
-  git_repo_subdir,
+  git_repo_subdir = "",
   source_git_commit = system("git rev-parse HEAD", intern = TRUE),
   source_git_branch = system("git rev-parse --abbrev-ref HEAD", intern = TRUE),
   project_entrypoint = "main",
   project_backend = "local"
 ) {
 
-  source_name <- paste(
-    git_repo_url,
-    git_repo_subdir,
-    sep = "#"
-  )
+  if (git_repo_subdir == "") {
+    source_name <- git_repo_url
+  } else {
+    source_name <- paste(
+      git_repo_url,
+      git_repo_subdir,
+      sep = "#"
+    )
+  }
 
   set_tag(
     key = "mlflow.source.git.repoURL",


### PR DESCRIPTION
* Fixes a bug that leaves a GH token in plain text in the `mlflow run` line in the UI

@tonyelhabr I _think_ this will work, but I can't really confirm till we test it on a private repo (the app)