### PR TITLE
`v0.6.4`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: lightMLFlow
 Title: A Lightweight, Opinionated R Wrapper for the 'MLFlow' REST API
-Version: 0.6.3
+Version: 0.6.4
 Authors@R: c(
     person("Matt", "Kaye", , "mrkaye97@gmail.com", role = c("aut", "cre")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "aut")

--- a/R/runs.R
+++ b/R/runs.R
@@ -833,7 +833,7 @@ start_run <- function(run_id = Sys.getenv("MLFLOW_RUN_ID"), experiment_id = get_
 
   assert_logical(nested)
   assert_string(run_id)
-  assert_string(experiment_id)
+  assert_string(experiment_id, null.ok = (!is.null(run_id) & run_id != ""))
   assert_mlflow_client(client)
 
   if (exists_active_run() && !nested) {


### PR DESCRIPTION
Fixes a small bug in the assertion on `experiment_id` for when a `run_id` is provided