### PR TITLE
Use poorman `bind_rows` as substitute for `rbind` in all places

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -36,9 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
@@ -49,9 +49,9 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
-      - name: Check
-        shell: Rscript {0}
-        run: install.packages("devtools"); devtools::check(error_on = "note")
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: false
 
   clobber-db:
     needs: R-CMD-check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,7 +48,8 @@ jobs:
 
       - name: Install libgit2-dev for git2r
         run: |
-          sudo apt-get libgit2-dev
+          sudo apt-get update
+          sudo apt-get install libgit2-dev
 
       - name: Check
         shell: Rscript {0}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,7 +46,9 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: |
+            any::pak
+            any::rcmdcheck
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,6 +46,10 @@ jobs:
 
       - uses: r-lib/actions/setup-renv@v2
 
+      - name: Install libgit2-dev for git2r
+        run: |
+          sudo apt-get libgit2-dev
+
       - name: Check
         shell: Rscript {0}
         run: install.packages("devtools"); devtools::check(error_on = "note")

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,9 +46,9 @@ jobs:
 
       - uses: r-lib/actions/setup-renv@v2
 
-      - uses: r-lib/actions/check-r-package@v2
-        with:
-          upload-snapshots: false
+      - name: Check
+        shell: Rscript {0}
+        run: install.packages("devtools"); devtools::check(error_on = "note")
 
   clobber-db:
     needs: R-CMD-check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest, r: '4.2.1'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,12 +44,7 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            any::pak
-            any::rcmdcheck
-          needs: check
+      - uses: r-lib/actions/setup-renv@v2
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,9 +44,10 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: rcmdcheck
+          extra-packages: any::rcmdcheck
+          needs: check
 
       - name: Check
         shell: Rscript {0}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-latest, r: '4.2.1'}
+          - {os: ubuntu-latest, r: '4.1.2'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,6 @@ Suggests:
     carrier,
     covr,
     ggplot2,
-    pak,
     secret,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Suggests:
     carrier,
     covr,
     ggplot2,
+    pak,
     secret,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,7 @@ Imports:
     tibble,
     withr
 Suggests: 
+    assertthat,
     carrier,
     covr,
     ggplot2,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,7 @@ Collate:
     'experiments.R'
     'globals.R'
     'lightMLFlow-package.R'
+    'poorman.R'
     'project.R'
     'registry.R'
     'rest.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: lightMLFlow
 Title: A Lightweight, Opinionated R Wrapper for the 'MLFlow' REST API
-Version: 0.6.7
+Version: 0.6.8
 Authors@R: c(
     person("Matt", "Kaye", , "mrkaye97@gmail.com", role = c("aut", "cre")),
     person("Tony", "ElHabr", , "anthonyelhabr@gmail.com", role = "aut")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# lightMLFlow 0.6.8
+
+* Fixes an `rbind` bug in `list_experiment`. (The same issue resolved in `seach_runs` in version `0.6.7`.) All `rbind` calls replaced with the internal "lite" version of `dplyr::bind_rows()`.
+
 # lightMLFlow 0.6.7
 
 * Fixes a bug with `search_runs` where `rbind`-ing runs with different numbers of columns (e.g. possible due to no logged parameters or no end time for a run) resulted in an error.

--- a/R/experiments.R
+++ b/R/experiments.R
@@ -104,7 +104,7 @@ list_experiments <- function(view_type = c("ACTIVE_ONLY", "DELETED_ONLY", "ALL")
 
   reduce(
     result,
-    rbind
+    bind_rows
   )
 }
 

--- a/R/poorman.R
+++ b/R/poorman.R
@@ -1,0 +1,55 @@
+
+names_are_invalid <- function(x) {
+  x == "" | is.na(x)
+}
+
+is_named <- function(x) {
+  nms <- names(x)
+  if (is.null(nms)) return(FALSE)
+  if (any(names_are_invalid(nms))) return(FALSE)
+  TRUE
+}
+
+is_df_or_vector <- function(x) {
+  res <- is.data.frame(x) || is.atomic(x)
+  if (isFALSE(res)) stop("You must pass vector(s) and/or data.frame(s).")
+  TRUE
+}
+
+is_nested <- function(lst) vapply(lst, function(x) inherits(x[1L], "list"), FALSE)
+
+flatten <- function(lst) {
+  nested <- is_nested(lst)
+  res <- c(lst[!nested], unlist(lst[nested], recursive = FALSE))
+  if (sum(nested)) Recall(res) else return(res)
+}
+
+#' @source <https://github.com/nathaneastwood/poorman/blob/master/R/bind.R#L79>
+bind_rows <- function(..., .id = NULL) {
+  lsts <- list(...)
+  lsts <- flatten(lsts)
+  lsts <- Filter(Negate(is.null), lsts)
+  lapply(lsts, function(x) is_df_or_vector(x))
+  lapply(lsts, function(x) if (is.atomic(x) && !is_named(x)) stop("Vectors must be named."))
+
+  if (!missing(.id)) {
+    lsts <- lapply(seq_along(lsts), function(i) {
+      nms <- names(lsts)
+      id_df <- data.frame(id = if (is.null(nms)) as.character(i) else nms[i], stringsAsFactors = FALSE)
+      colnames(id_df) <- .id
+      cbind(id_df, lsts[[i]])
+    })
+  }
+
+  nms <- unique(unlist(lapply(lsts, names)))
+  lsts <- lapply(
+    lsts,
+    function(x) {
+      if (!is.data.frame(x)) x <- data.frame(as.list(x), stringsAsFactors = FALSE)
+      for (i in nms[!nms %in% names(x)]) x[[i]] <- NA
+      x
+    }
+  )
+  names(lsts) <- NULL
+  do.call(rbind, lsts)
+}

--- a/R/runs.R
+++ b/R/runs.R
@@ -527,63 +527,8 @@ get_metric_history <- function(metric_key, run_id = get_active_run_id(), client 
         }
       ) %>%
       map(as_tibble) %>%
-      reduce(rbind)
+      reduce(bind_rows)
   }
-}
-
-names_are_invalid <- function(x) {
-  x == "" | is.na(x)
-}
-
-is_named <- function(x) {
-  nms <- names(x)
-  if (is.null(nms)) return(FALSE)
-  if (any(names_are_invalid(nms))) return(FALSE)
-  TRUE
-}
-
-is_df_or_vector <- function(x) {
-  res <- is.data.frame(x) || is.atomic(x)
-  if (isFALSE(res)) stop("You must pass vector(s) and/or data.frame(s).")
-  TRUE
-}
-
-is_nested <- function(lst) vapply(lst, function(x) inherits(x[1L], "list"), FALSE)
-
-flatten <- function(lst) {
-  nested <- is_nested(lst)
-  res <- c(lst[!nested], unlist(lst[nested], recursive = FALSE))
-  if (sum(nested)) Recall(res) else return(res)
-}
-
-#' @source <https://github.com/nathaneastwood/poorman/blob/master/R/bind.R#L79>
-bind_rows <- function(..., .id = NULL) {
-  lsts <- list(...)
-  lsts <- flatten(lsts)
-  lsts <- Filter(Negate(is.null), lsts)
-  lapply(lsts, function(x) is_df_or_vector(x))
-  lapply(lsts, function(x) if (is.atomic(x) && !is_named(x)) stop("Vectors must be named."))
-
-  if (!missing(.id)) {
-    lsts <- lapply(seq_along(lsts), function(i) {
-      nms <- names(lsts)
-      id_df <- data.frame(id = if (is.null(nms)) as.character(i) else nms[i], stringsAsFactors = FALSE)
-      colnames(id_df) <- .id
-      cbind(id_df, lsts[[i]])
-    })
-  }
-
-  nms <- unique(unlist(lapply(lsts, names)))
-  lsts <- lapply(
-    lsts,
-    function(x) {
-      if (!is.data.frame(x)) x <- data.frame(as.list(x), stringsAsFactors = FALSE)
-      for (i in nms[!nms %in% names(x)]) x[[i]] <- NA
-      x
-    }
-  )
-  names(lsts) <- NULL
-  do.call(rbind, lsts)
 }
 
 #' Search Runs

--- a/R/utils.R
+++ b/R/utils.R
@@ -173,7 +173,7 @@ parse_metric_data <- function(d) {
   } else {
     d %>%
       map(as.data.frame) %>%
-      reduce(rbind) %>%
+      reduce(bind_rows) %>%
       list()
   }
 }

--- a/renv.lock
+++ b/renv.lock
@@ -51,6 +51,13 @@
       "Repository": "CRAN",
       "Hash": "e8a22846fff485f0be3770c2da758713"
     },
+    "assertthat": {
+      "Package": "assertthat",
+      "Version": "0.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "50c838a310445e954bc13f26f26a6ecf"
+    },
     "aws.s3": {
       "Package": "aws.s3",
       "Version": "0.3.21",
@@ -85,6 +92,20 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "976cf154dfb043c012d87cddd8bca363"
+    },
+    "bslib": {
+      "Package": "bslib",
+      "Version": "0.3.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "56ae7e1987b340186a8a5a157c2ec358"
+    },
+    "cachem": {
+      "Package": "cachem",
+      "Version": "1.0.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "648c5b3d71e6a37e3043617489a0a0e9"
     },
     "callr": {
       "Package": "callr",
@@ -135,6 +156,13 @@
       "Repository": "CRAN",
       "Hash": "6d80a9fc3c0c8473153b54fa54719dfd"
     },
+    "cpp11": {
+      "Package": "cpp11",
+      "Version": "0.4.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ed588261931ee3be2c700d22e94a29ab"
+    },
     "crayon": {
       "Package": "crayon",
       "Version": "1.4.1",
@@ -169,6 +197,13 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "a0cbe758a531d054b537d16dff4d58a1"
+    },
+    "downlit": {
+      "Package": "downlit",
+      "Version": "0.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ba63dc9ab5a31f3209892437e40c5f60"
     },
     "ellipsis": {
       "Package": "ellipsis",
@@ -331,6 +366,13 @@
       "Repository": "CRAN",
       "Hash": "41287f1ac7d28a92f0a286ed507928d3"
     },
+    "memoise": {
+      "Package": "memoise",
+      "Version": "2.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e2817ccf4a065c5d9d7f2cfbe7c1d78c"
+    },
     "mgcv": {
       "Package": "mgcv",
       "Version": "1.8-38",
@@ -380,6 +422,13 @@
       "Repository": "CRAN",
       "Hash": "01f28d4278f15c76cddbea05899c5d6f"
     },
+    "pkgdown": {
+      "Package": "pkgdown",
+      "Version": "2.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "5d93e983873dc4803cd8e554cdcd40e5"
+    },
     "pkgload": {
       "Package": "pkgload",
       "Version": "1.2.4",
@@ -421,6 +470,20 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "97def703420c8ab10d8f0e6c72101e02"
+    },
+    "ragg": {
+      "Package": "ragg",
+      "Version": "1.2.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0db17bd5a1d4abfec76487b6f5dd957b"
+    },
+    "rappdirs": {
+      "Package": "rappdirs",
+      "Version": "0.3.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "5e3c5dc0b071b21fa128676560dbe94d"
     },
     "rematch2": {
       "Package": "rematch2",
@@ -471,12 +534,26 @@
       "Repository": "CRAN",
       "Hash": "06c85365a03fdaf699966cc1d3cf53ea"
     },
+    "sass": {
+      "Package": "sass",
+      "Version": "0.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "50cf822feb64bb3977bda0b7091be623"
+    },
     "scales": {
       "Package": "scales",
       "Version": "1.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "6f76f71042411426ec8df6c54f34e6dd"
+    },
+    "secret": {
+      "Package": "secret",
+      "Version": "1.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "b66e4c16becd7f937c47f4a7b9cfe35d"
     },
     "stringi": {
       "Package": "stringi",
@@ -499,12 +576,26 @@
       "Repository": "CRAN",
       "Hash": "b227d13e29222b4574486cfcbde077fa"
     },
+    "systemfonts": {
+      "Package": "systemfonts",
+      "Version": "1.0.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "90b28393209827327de889f49935140a"
+    },
     "testthat": {
       "Package": "testthat",
       "Version": "3.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "2a5c5646456762131ce40272964599d3"
+    },
+    "textshaping": {
+      "Package": "textshaping",
+      "Version": "0.3.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "1ab6223d3670fac7143202cb6a2d43d5"
     },
     "tibble": {
       "Package": "tibble",
@@ -547,6 +638,13 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "ad8cfff5694ac5b3c354f8f2044bd976"
+    },
+    "whisker": {
+      "Package": "whisker",
+      "Version": "0.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ca970b96d894e90397ed20637a0c1bbe"
     },
     "withr": {
       "Package": "withr",

--- a/renv.lock
+++ b/renv.lock
@@ -51,6 +51,13 @@
       "Repository": "CRAN",
       "Hash": "e8a22846fff485f0be3770c2da758713"
     },
+    "assertthat": {
+      "Package": "assertthat",
+      "Version": "0.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "50c838a310445e954bc13f26f26a6ecf"
+    },
     "aws.s3": {
       "Package": "aws.s3",
       "Version": "0.3.21",
@@ -85,6 +92,20 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "976cf154dfb043c012d87cddd8bca363"
+    },
+    "bslib": {
+      "Package": "bslib",
+      "Version": "0.3.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "56ae7e1987b340186a8a5a157c2ec358"
+    },
+    "cachem": {
+      "Package": "cachem",
+      "Version": "1.0.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "648c5b3d71e6a37e3043617489a0a0e9"
     },
     "callr": {
       "Package": "callr",
@@ -135,6 +156,13 @@
       "Repository": "CRAN",
       "Hash": "6d80a9fc3c0c8473153b54fa54719dfd"
     },
+    "cpp11": {
+      "Package": "cpp11",
+      "Version": "0.4.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ed588261931ee3be2c700d22e94a29ab"
+    },
     "crayon": {
       "Package": "crayon",
       "Version": "1.4.1",
@@ -169,6 +197,13 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "a0cbe758a531d054b537d16dff4d58a1"
+    },
+    "downlit": {
+      "Package": "downlit",
+      "Version": "0.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ba63dc9ab5a31f3209892437e40c5f60"
     },
     "ellipsis": {
       "Package": "ellipsis",
@@ -331,6 +366,13 @@
       "Repository": "CRAN",
       "Hash": "41287f1ac7d28a92f0a286ed507928d3"
     },
+    "memoise": {
+      "Package": "memoise",
+      "Version": "2.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e2817ccf4a065c5d9d7f2cfbe7c1d78c"
+    },
     "mgcv": {
       "Package": "mgcv",
       "Version": "1.8-38",
@@ -366,6 +408,19 @@
       "Repository": "CRAN",
       "Hash": "f4dbc5a47fd93d3415249884d31d6791"
     },
+    "pak": {
+      "Package": "pak",
+      "Version": "0.3.1.9000",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteUsername": "r-lib",
+      "RemoteRepo": "pak",
+      "RemoteRef": "main",
+      "RemoteSha": "95b8cad94f3dd864c293f553f8b516c6f2eaa69a",
+      "Remotes": "r-lib/pkgcache, r-lib/pkgdepends",
+      "Hash": "0d5366329d70394462113bba97b9717c"
+    },
     "pillar": {
       "Package": "pillar",
       "Version": "1.6.2",
@@ -379,6 +434,13 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "01f28d4278f15c76cddbea05899c5d6f"
+    },
+    "pkgdown": {
+      "Package": "pkgdown",
+      "Version": "2.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "5d93e983873dc4803cd8e554cdcd40e5"
     },
     "pkgload": {
       "Package": "pkgload",
@@ -421,6 +483,20 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "97def703420c8ab10d8f0e6c72101e02"
+    },
+    "ragg": {
+      "Package": "ragg",
+      "Version": "1.2.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0db17bd5a1d4abfec76487b6f5dd957b"
+    },
+    "rappdirs": {
+      "Package": "rappdirs",
+      "Version": "0.3.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "5e3c5dc0b071b21fa128676560dbe94d"
     },
     "rematch2": {
       "Package": "rematch2",
@@ -471,12 +547,26 @@
       "Repository": "CRAN",
       "Hash": "06c85365a03fdaf699966cc1d3cf53ea"
     },
+    "sass": {
+      "Package": "sass",
+      "Version": "0.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "50cf822feb64bb3977bda0b7091be623"
+    },
     "scales": {
       "Package": "scales",
       "Version": "1.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "6f76f71042411426ec8df6c54f34e6dd"
+    },
+    "secret": {
+      "Package": "secret",
+      "Version": "1.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "b66e4c16becd7f937c47f4a7b9cfe35d"
     },
     "stringi": {
       "Package": "stringi",
@@ -499,12 +589,26 @@
       "Repository": "CRAN",
       "Hash": "b227d13e29222b4574486cfcbde077fa"
     },
+    "systemfonts": {
+      "Package": "systemfonts",
+      "Version": "1.0.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "90b28393209827327de889f49935140a"
+    },
     "testthat": {
       "Package": "testthat",
       "Version": "3.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "2a5c5646456762131ce40272964599d3"
+    },
+    "textshaping": {
+      "Package": "textshaping",
+      "Version": "0.3.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "1ab6223d3670fac7143202cb6a2d43d5"
     },
     "tibble": {
       "Package": "tibble",
@@ -547,6 +651,13 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "ad8cfff5694ac5b3c354f8f2044bd976"
+    },
+    "whisker": {
+      "Package": "whisker",
+      "Version": "0.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ca970b96d894e90397ed20637a0c1bbe"
     },
     "withr": {
       "Package": "withr",

--- a/renv.lock
+++ b/renv.lock
@@ -51,13 +51,6 @@
       "Repository": "CRAN",
       "Hash": "e8a22846fff485f0be3770c2da758713"
     },
-    "assertthat": {
-      "Package": "assertthat",
-      "Version": "0.2.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "50c838a310445e954bc13f26f26a6ecf"
-    },
     "aws.s3": {
       "Package": "aws.s3",
       "Version": "0.3.21",
@@ -92,20 +85,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "976cf154dfb043c012d87cddd8bca363"
-    },
-    "bslib": {
-      "Package": "bslib",
-      "Version": "0.3.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "56ae7e1987b340186a8a5a157c2ec358"
-    },
-    "cachem": {
-      "Package": "cachem",
-      "Version": "1.0.6",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "648c5b3d71e6a37e3043617489a0a0e9"
     },
     "callr": {
       "Package": "callr",
@@ -156,13 +135,6 @@
       "Repository": "CRAN",
       "Hash": "6d80a9fc3c0c8473153b54fa54719dfd"
     },
-    "cpp11": {
-      "Package": "cpp11",
-      "Version": "0.4.3",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "ed588261931ee3be2c700d22e94a29ab"
-    },
     "crayon": {
       "Package": "crayon",
       "Version": "1.4.1",
@@ -197,13 +169,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "a0cbe758a531d054b537d16dff4d58a1"
-    },
-    "downlit": {
-      "Package": "downlit",
-      "Version": "0.4.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "ba63dc9ab5a31f3209892437e40c5f60"
     },
     "ellipsis": {
       "Package": "ellipsis",
@@ -366,13 +331,6 @@
       "Repository": "CRAN",
       "Hash": "41287f1ac7d28a92f0a286ed507928d3"
     },
-    "memoise": {
-      "Package": "memoise",
-      "Version": "2.0.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "e2817ccf4a065c5d9d7f2cfbe7c1d78c"
-    },
     "mgcv": {
       "Package": "mgcv",
       "Version": "1.8-38",
@@ -408,19 +366,6 @@
       "Repository": "CRAN",
       "Hash": "f4dbc5a47fd93d3415249884d31d6791"
     },
-    "pak": {
-      "Package": "pak",
-      "Version": "0.3.1.9000",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteUsername": "r-lib",
-      "RemoteRepo": "pak",
-      "RemoteRef": "main",
-      "RemoteSha": "95b8cad94f3dd864c293f553f8b516c6f2eaa69a",
-      "Remotes": "r-lib/pkgcache, r-lib/pkgdepends",
-      "Hash": "0d5366329d70394462113bba97b9717c"
-    },
     "pillar": {
       "Package": "pillar",
       "Version": "1.6.2",
@@ -434,13 +379,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "01f28d4278f15c76cddbea05899c5d6f"
-    },
-    "pkgdown": {
-      "Package": "pkgdown",
-      "Version": "2.0.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "5d93e983873dc4803cd8e554cdcd40e5"
     },
     "pkgload": {
       "Package": "pkgload",
@@ -483,20 +421,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "97def703420c8ab10d8f0e6c72101e02"
-    },
-    "ragg": {
-      "Package": "ragg",
-      "Version": "1.2.4",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "0db17bd5a1d4abfec76487b6f5dd957b"
-    },
-    "rappdirs": {
-      "Package": "rappdirs",
-      "Version": "0.3.3",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "5e3c5dc0b071b21fa128676560dbe94d"
     },
     "rematch2": {
       "Package": "rematch2",
@@ -547,26 +471,12 @@
       "Repository": "CRAN",
       "Hash": "06c85365a03fdaf699966cc1d3cf53ea"
     },
-    "sass": {
-      "Package": "sass",
-      "Version": "0.4.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "50cf822feb64bb3977bda0b7091be623"
-    },
     "scales": {
       "Package": "scales",
       "Version": "1.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "6f76f71042411426ec8df6c54f34e6dd"
-    },
-    "secret": {
-      "Package": "secret",
-      "Version": "1.1.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "b66e4c16becd7f937c47f4a7b9cfe35d"
     },
     "stringi": {
       "Package": "stringi",
@@ -589,26 +499,12 @@
       "Repository": "CRAN",
       "Hash": "b227d13e29222b4574486cfcbde077fa"
     },
-    "systemfonts": {
-      "Package": "systemfonts",
-      "Version": "1.0.4",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "90b28393209827327de889f49935140a"
-    },
     "testthat": {
       "Package": "testthat",
       "Version": "3.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "2a5c5646456762131ce40272964599d3"
-    },
-    "textshaping": {
-      "Package": "textshaping",
-      "Version": "0.3.6",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "1ab6223d3670fac7143202cb6a2d43d5"
     },
     "tibble": {
       "Package": "tibble",
@@ -651,13 +547,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "ad8cfff5694ac5b3c354f8f2044bd976"
-    },
-    "whisker": {
-      "Package": "whisker",
-      "Version": "0.4",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "ca970b96d894e90397ed20637a0c1bbe"
     },
     "withr": {
       "Package": "withr",


### PR DESCRIPTION
I encountered an error with `list_experiments`:

```
Error in rbind(deparse.level, ...) : 
  numbers of columns of arguments do not match
```

We resolved the same issue in `search_runs` by copying over code from `{poorman}` for `bind_rows` and calling `bind_rows`. We can do the same to resolve the issue with `list_experiments`. In fact, I went ahead and replaced all calls to `rbind` (except the one in `bind_rows` itself) with `bind_rows`. (there were just 2 more.)